### PR TITLE
Pipeline support and Set-AMTDevice

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Build and publish
         env:
           NUGET_KEY: ${{ secrets.PSGALLERYAPIKEY }}
-          BUILDVER: "1.0.1"
+          BUILDVER: "1.1.0"
         shell: pwsh
         run: |
           ./build_scripts/build.ps1

--- a/PowerAMT/Public/Get-AMTDevice.ps1
+++ b/PowerAMT/Public/Get-AMTDevice.ps1
@@ -11,14 +11,44 @@ function Get-AMTDevice {
     $headers.Add("Authorization", "Bearer $($Global:AMTSession.Token)")
     
     if(-not $Name -and -not $GUID) {
-        return Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/devices/") -Method GET -Headers $headers | Format-Table *
+        $returnArray = @()
+        $ResponseArray = Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/devices/") -Method GET -Headers $headers
+
+        foreach($Response in $ResponseArray){
+            $returnObject = New-Object -TypeName PSObject -Property @{
+                "GUID" = $Response.GUID
+                "Hostname" = $Response.hostname
+                "Tags" = $Response.tags
+                "MPSInstance" = $Response.MPSInstance
+                "ConnectionStatus" = $Response.ConnectionStatus
+                "MPSUsername" = $Response.MPSUsername
+                "TenantID" = $Response.tenantid
+            }
+            $returnArray += $returnObject
+        }
+        return $returnArray
     }
 
     if($null -ne $Name -and  $Name -ne ""){
-        return ((Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/devices/") -Method GET -Headers $headers) | Where-Object {$_.hostname -eq $Name}) | Format-Table *
+        $returnArray = @()
+        $ResponseArray = Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/devices/") -Method GET -Headers $headers
+        
+        foreach($Response in $ResponseArray){
+            $returnObject = New-Object -TypeName PSObject -Property @{
+                "GUID" = $Response.GUID
+                "Hostname" = $Response.hostname
+                "Tags" = $Response.tags
+                "MPSInstance" = $Response.MPSInstance
+                "ConnectionStatus" = $Response.ConnectionStatus
+                "MPSUsername" = $Response.MPSUsername
+                "TenantID" = $Response.tenantid
+            }
+            $returnArray += $returnObject
+        }
+        return $returnArray | Where-Object {$_.hostname -eq $Name}
     }
 
     if($null -ne $GUID -and $GUID -ne ""){
-        return (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/devices/$GUID") -Method GET -Headers $headers) | Format-Table *
+        return (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/devices/$GUID") -Method GET -Headers $headers)
     }
 }

--- a/PowerAMT/Public/Get-AMTDeviceBootOptions.ps1
+++ b/PowerAMT/Public/Get-AMTDeviceBootOptions.ps1
@@ -1,15 +1,19 @@
 function Get-AMTDeviceBootOptions {
     param (
-        [Parameter(Mandatory)][string]$GUID
+        [Parameter(Mandatory,ValueFromPipelineByPropertyName)][string]$GUID
     )
-
-    if($null -eq $Global:AMTSession){
-        throw "No active AMT session. Create a session first with Connect-AMTManagement"
+    begin {
+        if($null -eq $Global:AMTSession){
+            throw "No active AMT session. Create a session first with Connect-AMTManagement"
+        }
     }
-    $headers=@{}
-    $headers.Add("Authorization", "Bearer $($Global:AMTSession.Token)")
-
-    if($null -ne $GUID -and $GUID -ne ""){
-        return (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/capabilities/$GUID") -Method GET -Headers $headers)
+    
+    process {
+        $headers=@{}
+        $headers.Add("Authorization", "Bearer $($Global:AMTSession.Token)")
+    
+        if($null -ne $GUID -and $GUID -ne ""){
+            return (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/capabilities/$GUID") -Method GET -Headers $headers)
+        }
     }
 }

--- a/PowerAMT/Public/Get-AMTDeviceHardwareDetails.ps1
+++ b/PowerAMT/Public/Get-AMTDeviceHardwareDetails.ps1
@@ -1,6 +1,6 @@
 function Get-AMTDeviceDetail {
     param (
-        [Parameter(Mandatory)][string]$GUID
+        [Parameter(Mandatory,ValueFromPipelineByPropertyName)][string]$GUID
     )
 
     if($null -eq $Global:AMTSession){

--- a/PowerAMT/Public/Get-AMTDevicePowerState.ps1
+++ b/PowerAMT/Public/Get-AMTDevicePowerState.ps1
@@ -1,34 +1,36 @@
-# mps/api/v1/amt/power/state/
-
 function Get-AMTDevicePowerState {
     param (
-        [Parameter(Mandatory)][string]$GUID
+        [Parameter(Mandatory,ValueFromPipelineByPropertyName)][string]$GUID
     )
-
-    $PossiblePowerStates = @{
-        "0"= "-";
-        "2"= "On";
-        "3"= "Sleep (Light)";
-        "4"= "Sleep (Deep)";
-        "6"= "Off";
-        "7"= "Hybernate";
-        "8"= "Off (Soft)";
-        "9"= "Off (Hard)";
-        "13"= "Off (Hard Graceful)";
-      }
-
-    if($null -eq $Global:AMTSession){
-        throw "No active AMT session. Create a session first with Connect-AMTManagement"
-    }
-    $headers=@{}
-    $headers.Add("Authorization", "Bearer $($Global:AMTSession.Token)")
-
-    if($null -ne $GUID -and $GUID -ne ""){
-        $CurrentPowerState = (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/state/$GUID") -Method GET -Headers $headers).powerstate
-        $ReturnObject = New-Object -TypeName psobject -Property @{
-            PowerStateID = $CurrentPowerState
-            PowerStateDisplayName = $PossiblePowerStates["$CurrentPowerState"]
+    begin {
+        $PossiblePowerStates = @{
+            "0"= "-";
+            "2"= "On";
+            "3"= "Sleep (Light)";
+            "4"= "Sleep (Deep)";
+            "6"= "Off";
+            "7"= "Hybernate";
+            "8"= "Off (Soft)";
+            "9"= "Off (Hard)";
+            "13"= "Off (Hard Graceful)";
+          }
+    
+        if($null -eq $Global:AMTSession){
+            throw "No active AMT session. Create a session first with Connect-AMTManagement"
         }
-        return $ReturnObject
+    }
+    process {
+        $headers=@{}
+        $headers.Add("Authorization", "Bearer $($Global:AMTSession.Token)")
+
+        if($null -ne $GUID -and $GUID -ne ""){
+            $CurrentPowerState = (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/state/$GUID") -Method GET -Headers $headers).powerstate
+            $ReturnObject = New-Object -TypeName psobject -Property @{
+                GUID = $GUID
+                PowerStateID = $CurrentPowerState
+                PowerStateDisplayName = $PossiblePowerStates["$CurrentPowerState"]
+            }
+            return $ReturnObject | Select-Object GUID,PowerStateDisplayName,PowerStateID
+        }
     }
 }

--- a/PowerAMT/Public/Invoke-AMTPowerAction.ps1
+++ b/PowerAMT/Public/Invoke-AMTPowerAction.ps1
@@ -1,21 +1,26 @@
 function Invoke-AMTPowerAction {
     param(
-        [Parameter(Mandatory)]$GUID,
+        [Parameter(Mandatory,ValueFromPipelineByPropertyName)]$GUID,
         [Parameter(Mandatory)][int]$PowerAction
     )
-    if($null -eq $Global:AMTSession){
-        throw "No active AMT session. Create a session first with Connect-AMTManagement"
+
+    begin {
+        if($null -eq $Global:AMTSession){
+            throw "No active AMT session. Create a session first with Connect-AMTManagement"
+        }
     }
-    $headers=@{}
-    $headers.Add("Authorization", "Bearer $($Global:AMTSession.Token)")
-
-    $Body = @{
-        "action"=$PowerAction
-        "useSOL"=$false
-    } | ConvertTo-Json
-
-    if($null -ne $GUID -and $GUID -ne ""){
-        return (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/bootoptions/$GUID") -Method POST `
-        -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body).body
+    process {
+        $headers=@{}
+        $headers.Add("Authorization", "Bearer $($Global:AMTSession.Token)")
+    
+        $Body = @{
+            "action"=$PowerAction
+            "useSOL"=$false
+        } | ConvertTo-Json
+    
+        if($null -ne $GUID -and $GUID -ne ""){
+            return (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/bootoptions/$GUID") -Method POST `
+            -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body).body
+        }
     }
 }

--- a/PowerAMT/Public/Restart-AMTDevice.ps1
+++ b/PowerAMT/Public/Restart-AMTDevice.ps1
@@ -1,21 +1,26 @@
 function Restart-AMTDevice {
     param(
-        [Parameter(Mandatory)]$GUID,
+        [Parameter(Mandatory,ValueFromPipelineByPropertyName)]$GUID,
         [switch]$Soft
     )
-    if($null -eq $Global:AMTSession){
-        throw "No active AMT session. Create a session first with Connect-AMTManagement"
+    begin {
+        if($null -eq $Global:AMTSession){
+            throw "No active AMT session. Create a session first with Connect-AMTManagement"
+        }
     }
-    $headers=@{}
-    $headers.Add("Authorization", "Bearer $($Global:AMTSession.Token)")
-
-    $Body = @{
-        "action"=if ($soft) {14} else {10}
-        "useSOL"=$false
-    } | ConvertTo-Json
-
-    if($null -ne $GUID -and $GUID -ne ""){
-        return (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/action/$GUID") -Method POST `
-        -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body).body
+    
+    process {
+        $headers=@{}
+        $headers.Add("Authorization", "Bearer $($Global:AMTSession.Token)")
+    
+        $Body = @{
+            "action"=if ($soft) {14} else {10}
+            "useSOL"=$false
+        } | ConvertTo-Json
+    
+        if($null -ne $GUID -and $GUID -ne ""){
+            return (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/action/$GUID") -Method POST `
+            -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body).body
+        }
     }
 }

--- a/PowerAMT/Public/Set-AMTDevice.ps1
+++ b/PowerAMT/Public/Set-AMTDevice.ps1
@@ -1,0 +1,42 @@
+function Set-AMTDevice {
+    param(
+        [Parameter(Mandatory,ValueFromPipelineByPropertyName)][string]$GUID,
+        [string] $Name,
+        [string[]] $Tags
+    )
+
+    begin {
+        if($null -eq $Global:AMTSession){
+            throw "No active AMT session. Create a session first with Connect-AMTManagement"
+        }
+    }
+    process {
+
+        $headers=@{}
+        $headers.Add("Authorization", "Bearer $($Global:AMTSession.Token)")
+        $headers.Add("Content-Type", "application/json")
+
+        $body = @{
+            "guid"=$GUID
+        }
+
+        if($Name -ne "" -and $null -ne $Name){
+            $body | Add-Member -NotePropertyName "hostname" -NotePropertyValue $Name
+        }
+
+        if($Tags.Count -gt 0){
+            $body | Add-Member -NotePropertyName "tags" -NotePropertyValue $Tags
+        }
+
+        if($null -eq $Tags){
+            $body | Add-Member -NotePropertyName "tags" -NotePropertyValue @()
+        }
+
+        $body = $body | ConvertTo-Json
+
+        if($null -ne $GUID -and $GUID -ne ""){
+            return (Invoke-RestMethod -Uri 'https://192.168.200.200/mps/api/v1/devices' -Method PATCH -Headers $headers -ContentType 'application/json' -Body $body)
+        }
+    }
+
+}

--- a/PowerAMT/Public/Start-AMTDevice.ps1
+++ b/PowerAMT/Public/Start-AMTDevice.ps1
@@ -1,20 +1,26 @@
 function Start-AMTDevice {
     param(
-        [Parameter(Mandatory)]$GUID
+        [Parameter(Mandatory,ValueFromPipelineByPropertyName)]$GUID
     )
-    if($null -eq $Global:AMTSession){
-        throw "No active AMT session. Create a session first with Connect-AMTManagement"
+    
+    begin {
+        if($null -eq $Global:AMTSession){
+            throw "No active AMT session. Create a session first with Connect-AMTManagement"
+        } 
     }
-    $headers=@{}
-    $headers.Add("Authorization", "Bearer $($Global:AMTSession.Token)")
-
-    $Body = @{
-        "action"=2
-        "useSOL"=$false
-    } | ConvertTo-Json
-
-    if($null -ne $GUID -and $GUID -ne ""){
-        return (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/action/$GUID") -Method POST `
-        -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body).body
+    
+    process {
+        $headers=@{}
+        $headers.Add("Authorization", "Bearer $($Global:AMTSession.Token)")
+    
+        $Body = @{
+            "action"=2
+            "useSOL"=$false
+        } | ConvertTo-Json
+    
+        if($null -ne $GUID -and $GUID -ne ""){
+            return (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/action/$GUID") -Method POST `
+            -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body).body
+        }
     }
 }

--- a/PowerAMT/Public/Stop-AMTDevice.ps1
+++ b/PowerAMT/Public/Stop-AMTDevice.ps1
@@ -1,21 +1,27 @@
 function Stop-AMTDevice {
     param(
-        [Parameter(Mandatory)]$GUID,
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]$GUID,
         [switch]$Soft
     )
-    if($null -eq $Global:AMTSession){
-        throw "No active AMT session. Create a session first with Connect-AMTManagement"
+
+    begin {
+        if($null -eq $Global:AMTSession){
+            throw "No active AMT session. Create a session first with Connect-AMTManagement"
+        }
     }
-    $headers=@{}
-    $headers.Add("Authorization", "Bearer $($Global:AMTSession.Token)")
-
-    $Body = @{
-        "action"=if ($soft) {12} else {8}
-        "useSOL"=$false
-    } | ConvertTo-Json
-
-    if($null -ne $GUID -and $GUID -ne ""){
-        return (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/action/$GUID") -Method POST `
-        -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body).body
+    
+    process {
+        $headers=@{}
+        $headers.Add("Authorization", "Bearer $($Global:AMTSession.Token)")
+    
+        $Body = @{
+            "action"=if ($soft) {12} else {8}
+            "useSOL"=$false
+        } | ConvertTo-Json
+    
+        if($null -ne $GUID -and $GUID -ne ""){
+            return (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/action/$GUID") -Method POST `
+            -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body).body
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ C:\> Install-Module -Name PowerAMT
 
 ## Maintainer
 
-- [Michael Mumenthaler]("https://github.com/michaelmumenthaler")
+- [Michael Mumenthaler](https://github.com/michaelmumenthaler)
 
 ## Todos:
 


### PR DESCRIPTION
# What changed

- You can now change a device's tags and name with Set-AMTDevice
- Pipelines are now supported! Try it out:
```PowerShell 
C:\> Get-AMTDevice | Set-AMTDevice -Tags "London","Store"
```

Signed-off-by: michaelmumenthaler <michi.mumi@gmail.com>