### PR TITLE
add skipcertcheck to all restmethods on PS Versions > 5

### DIFF
--- a/PowerAMT/Public/Get-AMTDevice.ps1
+++ b/PowerAMT/Public/Get-AMTDevice.ps1
@@ -105,8 +105,11 @@ function Get-AMTDevice {
         
         if(-not $Name -and -not $GUID) {
             $returnArray = @()
-            $ResponseArray = Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/devices?%24top=$Limit") -Method GET -Headers $headers
-    
+            if($PSVersionTable.PSVersion.Major -le 5) {
+                $ResponseArray = Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/devices?%24top=$Limit") -Method GET -Headers $headers
+            } else {
+                $ResponseArray = Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/devices?%24top=$Limit") -Method GET -Headers $headers -SkipCertificateCheck
+            }
             foreach($Response in $ResponseArray){
                 $returnObject = New-Object -TypeName PSObject -Property @{
                     "GUID" = $Response.GUID
@@ -123,9 +126,14 @@ function Get-AMTDevice {
         }
     
         if($null -ne $Name -and  $Name -ne ""){
+            $uri = "https://" + $Global:AMTSession.Address + "/mps/api/v1/devices?%24top=$Limit"
             $returnArray = @()
-            $ResponseArray = Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/devices?%24top=$Limit") -Method GET -Headers $headers
-            
+
+            if($PSVersionTable.PSVersion.Major -le 5) {
+                $ResponseArray = Invoke-RestMethod -Uri $uri -Method GET -Headers $headers
+            } else {
+                $ResponseArray = Invoke-RestMethod -Uri $uri -Method GET -Headers $headers -SkipCertificateCheck
+            }
             foreach($Response in $ResponseArray){
                 $returnObject = New-Object -TypeName PSObject -Property @{
                     "GUID" = $Response.GUID
@@ -142,7 +150,13 @@ function Get-AMTDevice {
         }
     
         if($null -ne $GUID -and $GUID -ne ""){
-            return (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/devices/$GUID") -Method GET -Headers $headers)
+            $uri = "https://" + $Global:AMTSession.Address + "/mps/api/v1/devices/" + $GUID
+            if ($psversiontable.PSVersion.Major -le 5) {
+                $Response = Invoke-RestMethod -Uri $uri -Method GET -Headers $headers
+            } else {
+                $Response = Invoke-RestMethod -Uri $uri -Method GET -Headers $headers -SkipCertificateCheck
+            }
+            return $Response
         }
     }
     

--- a/PowerAMT/Public/Get-AMTDeviceBootOptions.ps1
+++ b/PowerAMT/Public/Get-AMTDeviceBootOptions.ps1
@@ -112,8 +112,15 @@ function Get-AMTDeviceBootOptions {
         $headers=@{}
         $headers.Add("Authorization", "Bearer $($Global:AMTSession.Token)")
     
+        $uri = "https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/capabilities/$GUID"
+
         if($null -ne $GUID -and $GUID -ne ""){
-            return (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/capabilities/$GUID") -Method GET -Headers $headers)
+            if ($PSVersionTable.PSVersion.Major -le 5) {
+                $Response = Invoke-RestMethod -Uri $uri -Method GET -Headers $headers
+            } else {
+                $Response = Invoke-RestMethod -Uri $uri -Method GET -Headers $headers -SkipCertificateCheck
+            }
+            return $Response
         }
     }
 }

--- a/PowerAMT/Public/Get-AMTDeviceDetail.ps1
+++ b/PowerAMT/Public/Get-AMTDeviceDetail.ps1
@@ -58,6 +58,14 @@ function Get-AMTDeviceDetail {
     $headers.Add("Authorization", "Bearer $($Global:AMTSession.Token)")
 
     if($null -ne $GUID -and $GUID -ne ""){
-        return (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/hardwareInfo/$GUID") -Method GET -Headers $headers)
+        $uri = "https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/hardwareInfo/$GUID"
+        
+        if ($PSVersionTable.PSVersion.Major -le 5) {
+            $response = Invoke-WebRequest -Uri $uri -Headers $headers -Method GET
+        } else {
+            $response = Invoke-WebRequest -Uri $uri -Headers $headers -Method GET -SkipCertificateCheck
+        }
+
+        return $response.content | ConvertFrom-Json
     }
 }

--- a/PowerAMT/Public/Get-AMTDevicePowerState.ps1
+++ b/PowerAMT/Public/Get-AMTDevicePowerState.ps1
@@ -69,7 +69,12 @@ function Get-AMTDevicePowerState {
         $headers.Add("Authorization", "Bearer $($Global:AMTSession.Token)")
 
         if($null -ne $GUID -and $GUID -ne ""){
-            $CurrentPowerState = (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/state/$GUID") -Method GET -Headers $headers).powerstate
+            $uri = "https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/state/$GUID"
+            if ($PSVersionTable.PSVersion.Major -le 5) {
+                $CurrentPowerState = (Invoke-RestMethod -Uri $uri -Method GET -Headers $headers).powerstate
+            } else {
+                $CurrentPowerState = (Invoke-RestMethod -Uri $uri -Method GET -Headers $headers -SkipCertificateCheck).powerstate
+            }
             $ReturnObject = New-Object -TypeName psobject -Property @{
                 GUID = $GUID
                 PowerStateID = $CurrentPowerState

--- a/PowerAMT/Public/Get-AMTDevicesStats.ps1
+++ b/PowerAMT/Public/Get-AMTDevicesStats.ps1
@@ -29,6 +29,14 @@ function Get-AMTDevicesStats {
     $headers=@{}
     $headers.Add("Authorization", "Bearer $($Global:AMTSession.Token)")
 
-    return (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/devices/stats") -Method GET -Headers $headers)
+    $uri = "https://" + $Global:AMTSession.Address + "/mps/api/v1/devices/stats"
+
+    if ($PSVersionTable.PSVersion.Major -le 5){
+        $Response = Invoke-RestMethod -Uri $uri -Method GET -Headers $headers
+    } else {
+        $Response = Invoke-RestMethod -Uri $uri -Method GET -Headers $headers -SkipCertificateCheck
+    }
+
+    return $Response
 
 }

--- a/PowerAMT/Public/Invoke-AMTPowerAction.ps1
+++ b/PowerAMT/Public/Invoke-AMTPowerAction.ps1
@@ -63,8 +63,16 @@ function Invoke-AMTPowerAction {
             } | ConvertTo-Json
         
             if($null -ne $GUID -and $GUID -ne ""){
-                $Response = (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/bootoptions/$device") -Method POST `
-                -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body).body
+
+                $uri = "https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/bootoptions/$device"
+                
+                if ($PSVersionTable.PSVersion.Major -le 5){
+                    $Response = (Invoke-RestMethod -Uri $uri -Method POST `
+                    -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body).body
+                } else {
+                    $Response = (Invoke-RestMethod -Uri $uri -Method POST `
+                    -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body -SkipCertificateCheck).body
+                }
                 $ReturnObject = New-Object -TypeName PSObject -Property @{
                     GUID = $device
                     ReturnValue = $Response.ReturnValue

--- a/PowerAMT/Public/Restart-AMTDevice.ps1
+++ b/PowerAMT/Public/Restart-AMTDevice.ps1
@@ -70,8 +70,17 @@ function Restart-AMTDevice {
             } | ConvertTo-Json
         
             if($null -ne $GUID -and $GUID -ne ""){
-                $Response = (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/action/$device") -Method POST `
-                -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body).body
+
+                $uri = "https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/action/$device"
+
+                if ($PSVersionTable.PSVersion.Major -le 5){
+                    $Response = (Invoke-RestMethod -Uri $uri -Method POST `
+                    -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body).body
+                } else {
+                    $Response = (Invoke-RestMethod -Uri $uri -Method POST `
+                    -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body -SkipCertificateCheck).body
+                }
+
                 $ReturnObject = New-Object -TypeName PSObject -Property @{
                     GUID = $device
                     ReturnValue = $Response.ReturnValue

--- a/PowerAMT/Public/Set-AMTDevice.ps1
+++ b/PowerAMT/Public/Set-AMTDevice.ps1
@@ -106,7 +106,15 @@ function Set-AMTDevice {
             $body = $body | ConvertTo-Json
     
             if($null -ne $GUID -and $GUID -ne ""){
-                return (Invoke-RestMethod -Uri ("https://"+ $Global:AMTSession.Address + "/mps/api/v1/devices") -Method PATCH -Headers $headers -ContentType 'application/json' -Body $body)
+                $uri = "https://"+ $Global:AMTSession.Address + "/mps/api/v1/devices"
+
+                if ($PSVersionTable.PSVersion.Major -le 5){
+                    $Response = Invoke-RestMethod -Uri $uri -Method PATCH -Headers $headers -ContentType 'application/json' -Body $body
+                } else {
+                    $Response = Invoke-RestMethod -Uri $uri -Method PATCH -Headers $headers -ContentType 'application/json' -Body $body -SkipCertificateCheck
+                }
+
+                return $Response
             }
         }
     }

--- a/PowerAMT/Public/Start-AMTDevice.ps1
+++ b/PowerAMT/Public/Start-AMTDevice.ps1
@@ -58,8 +58,16 @@ function Start-AMTDevice {
             } | ConvertTo-Json
         
             if($null -ne $GUID -and $GUID -ne ""){
-                $Response = (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/action/$device") -Method POST `
-                -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body).body
+
+                $uri = "https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/action/$device"
+
+                if($PSVersionTable.PSVersion.Major -le 5){
+                    $Response = (Invoke-RestMethod -Uri $uri -Method POST `
+                    -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body).body
+                } else {
+                    $Response = (Invoke-RestMethod -Uri $uri -Method POST `
+                    -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body -SkipCertificateCheck).body
+                }
                 $ReturnObject = New-Object -TypeName PSObject -Property @{
                     GUID = $device
                     ReturnValue = $Response.ReturnValue

--- a/PowerAMT/Public/Stop-AMTDevice.ps1
+++ b/PowerAMT/Public/Stop-AMTDevice.ps1
@@ -71,8 +71,17 @@ function Stop-AMTDevice {
             } | ConvertTo-Json
         
             if($null -ne $GUID -and $GUID -ne ""){
-                $Response = (Invoke-RestMethod -Uri ("https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/action/$GUID") -Method POST `
-                -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body).body
+
+                $uri = "https://" + $Global:AMTSession.Address + "/mps/api/v1/amt/power/action/$GUID"
+
+                if ($PSVersionTable.PSVersion.Major -le 5){
+                    $Response = (Invoke-RestMethod -Uri $uri -Method POST `
+                    -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body).body
+                } else {
+                    $Response = (Invoke-RestMethod -Uri $uri -Method POST `
+                    -UseBasicParsing -ContentType 'application/json' -Headers $headers -body $body -SkipCertificateCheck).body
+                }
+
                 $ReturnObject = New-Object -TypeName PSObject -Property @{
                     GUID = $device
                     ReturnValue = $Response.ReturnValue


### PR DESCRIPTION
# Changes
- Add Compatibility vor PowerShell 7 (Issue: #3)
- Rename File from "Get-AMTDeviceHardwareDetails.ps1" to "Get-AMTDeviceDetail.ps1" to fix an issue with the command not exporting properly (Issue: #4)

Signed-off-by: Michael Mumenthaler <michael.mumenthaler@protonmail.com>